### PR TITLE
Copy foreign_cc dependencies. Symlink is not enough.

### DIFF
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -18,7 +18,7 @@ def create_configure_script(
 
     script = []
     for ext_dir in inputs.ext_build_dirs:
-        script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
+        script += ["##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename]
 
     script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
 
@@ -50,7 +50,7 @@ def create_make_script(
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
     script = []
     for ext_dir in inputs.ext_build_dirs:
-        script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
+        script += ["##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename]
 
     script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
 

--- a/tools/build_defs/shell_toolchain/toolchains/commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/commands.bzl
@@ -130,6 +130,18 @@ If file is passed, symlink it into the target directory.""",
 Symlink all files from source directory to target directory (create the target directory if needed).
 NB symlinks from the source directory are copied.""",
     ),
+    "copy_to_dir": CommandInfo(
+        arguments = [
+            ArgumentInfo(
+                name = "source",
+                type_ = type(""),
+                doc = "Source directory",
+            ),
+            ArgumentInfo(name = "target", type_ = type(""), doc = "Target directory"),
+        ],
+        doc = """
+Copy all files from source directory to target directory (create the target directory if needed).""",
+    ),
     "script_prelude": CommandInfo(
         arguments = [],
         doc = "Function for setting necessary environment variables for the platform",

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "BAZEL_GEN_ROOT"
 
 def os_name():
     return "linux"
@@ -94,6 +94,21 @@ elif [[ -L $1 ]]; then
   cp --no-target-directory $1 ${target}
 else
   echo "Can not copy $1"
+fi
+"""
+    return FunctionAndCall(text = text)
+
+def copy_to_dir(source, target):
+    text = """
+local target="$2"
+mkdir -p ${target}
+
+if [[ -d $1 ]]; then
+  cp -r $1 ${target}/
+elif [[ -f $1 ]]; then
+  cp $1 ${target}/
+else
+  echo "Cannot copy $1"
 fi
 """
     return FunctionAndCall(text = text)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "BAZEL_GEN_ROOT"
 
 def os_name():
     return "linux"
@@ -60,7 +60,7 @@ def replace_in_files(dir, from_, to_):
   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
-    )
+)
 
 def copy_dir_contents_to_dir(source, target):
     return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
@@ -97,6 +97,22 @@ else
 fi
 """
     return FunctionAndCall(text = text)
+
+def copy_to_dir(source, target):
+    text = """
+local target="$2"
+mkdir -p ${target}
+
+if [[ -d $1 ]]; then
+  cp -r $1 ${target}/
+elif [[ -f $1 ]]; then
+  cp $1 ${target}/
+else
+  echo "Cannot copy $1"
+fi
+"""
+    return FunctionAndCall(text = text)
+
 
 def script_prelude():
     return "set -e"

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "BAZEL_GEN_ROOT"
 
 def os_name():
     return "osx"
@@ -104,6 +104,25 @@ elif [[ -L $1 ]]; then
   cp $1 ${target}
 else
   echo "Can not copy $1"
+fi
+"""
+    return FunctionAndCall(text = text)
+
+def copy_to_dir(source, target):
+    text = """
+local target="$2"
+mkdir -p ${target}
+
+if [[ -d $1 ]]; then
+  cp -r $1 ${target}/
+  # The files in the bazel cache dir on MacOS are write-once. Make the copy
+  # owner writable.
+  chmod -R u+w "${target}/$(basename $1)"
+elif [[ -f $1 ]]; then
+  cp $1 ${target}/
+  chmod -R u+w "${target}/$(basename $1)"
+else
+  echo "Cannot copy $1"
 fi
 """
     return FunctionAndCall(text = text)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "BAZEL_GEN_ROOT"
 
 def os_name():
     return "windows"
@@ -94,6 +94,21 @@ elif [[ -L $1 ]]; then
   cp --no-target-directory $1 ${target}
 else
   echo "Can not copy $1"
+fi
+"""
+    return FunctionAndCall(text = text)
+
+def copy_to_dir(source, target):
+    text = """
+local target="$2"
+mkdir -p ${target}
+
+if [[ -d $1 ]]; then
+  cp -r $1 ${target}/
+elif [[ -f $1 ]]; then
+  cp $1 ${target}/
+else
+  echo "Cannot copy $1"
 fi
 """
     return FunctionAndCall(text = text)


### PR DESCRIPTION
A foreign_cc-built dep could be included by multiple other foreign_cc
targets. If these other targets are built in parallel, they could update
the dep's BAZEL_GEN_ROOT values inside the .pc, .cmake, etc.,
simulataneously. This could break the build in unpredictable ways.

To fix this, each target must have a *copy* of the dep. A symlink of the
dep is not sufficient.

Make the copy owner writable. This fixes the sed permission error on
MacOS where the files in bazel cache dir are write-once only.

This also fixes #344, where ${EXT_BUILD_DEPS} env var is not expanded
by pkgconfig or cmake files.

This fix also effectively reverted #324